### PR TITLE
Fix typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## *DICT - QuickStart*
 
-Bem vindo ao QuickStart do DICT, o Diretório de Identificadores de Contas Transacionais
+Bem-vindo ao _QuickStart_ do DICT, o Diretório de Identificadores de Contas Transacionais
 do PIX (Sistema de Pagamentos Instantâneos do Banco Central do Brasil). O objetivo 
 é guiar o usuário/desenvolvedor no primeiro contato com a API do DICT. O público-alvo
 são profissionais de TI dos Prestadores de Serviços de Pagamentos (PSP). Se você


### PR DESCRIPTION
Correção de um erro de digitação/ortografia.
Faltava um hífen no bem-vindo do README.

Bem vindo -> bem-vindo

Ref.: https://querobolsa.com.br/revista/bem-vindo-ou-bem-vindo-como-se-escreve